### PR TITLE
Fixed for Python3

### DIFF
--- a/example/shovel/bar.py
+++ b/example/shovel/bar.py
@@ -8,7 +8,7 @@ def hello(name='Foo'):
         shovel bar.hello
         shovel bar.hello --name=Erin
         http://localhost:3000/bar.hello?Erin'''
-    print 'Hello, %s' % name
+    print('Hello, %s' % name)
 
 @task
 def args(*args):
@@ -21,7 +21,7 @@ def args(*args):
         shovel bar.args 1 2 3 4
         http://localhost:3000/bar.args?1&2&3&4'''
     for arg in args:
-        print 'You said "%s"' % arg
+        print('You said "%s"' % arg)
 
 @task
 def kwargs(**kwargs):
@@ -34,4 +34,4 @@ def kwargs(**kwargs):
         shovel bar.kwargs --foo=5 --bar 5 --howdy hey
         http://localhost:3000/bar.kwargs?foo=5&bar=5&howdy=hey'''
     for key, val in kwargs.items():
-        print 'You said "%s" => "%s"' % (key, val)
+        print('You said "%s" => "%s"' % (key, val))

--- a/example/shovel/foo.py
+++ b/example/shovel/foo.py
@@ -7,4 +7,4 @@ def howdy(times=1):
     Examples:
         shovel foo.howdy 10
         http://localhost:3000/foo.howdy?15'''
-    print '\n'.join(['Howdy'] * int(times))
+    print('\n'.join(['Howdy'] * int(times)))

--- a/example/shovel/test/debug.py
+++ b/example/shovel/test/debug.py
@@ -7,7 +7,7 @@ def verbose():
     Examples:
     shovel test.debug.verbose
     http://localhost:3000/test.debug.verbose'''
-    print 'Good news, everyone!\n' * 100
+    print('Good news, everyone!\n' * 100)
 
 @task
 def difference(a, b):

--- a/shovel.py
+++ b/shovel.py
@@ -3,16 +3,16 @@ from shovel import task
 @task
 def hello(name):
     '''Prints hello and the provided name'''
-    print 'Hello, %s!' % name
+    print('Hello, %s!' % name)
 
 @task
 def sumnum(*args):
     '''Computes the sum of the provided numbers'''
-    print '%s = %f' % (' + '.join(args), sum(float(arg) for arg in args))
+    print('%s = %f' % (' + '.join(args), sum(float(arg) for arg in args)))
 
 @task
 def attributes(name, **kwargs):
     '''Prints a name, and all keyword attributes'''
-    print '%s has attributes:' % name
+    print('%s has attributes:' % name)
     for key, value in kwargs.items():
-        print '\t%s => %s' % (key, value)
+        print('\t%s => %s' % (key, value))

--- a/shovel/__init__.py
+++ b/shovel/__init__.py
@@ -323,16 +323,16 @@ def help_helper(tasks):
 def help(*names):
     '''Display information about the provided task name, or available tasks'''
     if not len(names):
-        print help_helper(Task.find())
+        print(help_helper(Task.find()))
     else:
         for name in names:
             tasks = Task.find(name)
             if not tasks:
-                print 'Could not find task or module "%s"' % name
+                print('Could not find task or module "%s"' % name)
             elif len(tasks) == 1:
-                print tasks[0].help()
+                print(tasks[0].help())
             else:
-                print help_helper(tasks)
+                print(help_helper(tasks))
 
 def load():
     '''Load tasks from files'''


### PR DESCRIPTION
The Python2 style "print" was breaking when installing with Python3, regardless of the request to use 2to3 (sudo pip-3.3 install shovel). Better to manually use Python3 style print function everywhere.
