### PR TITLE
Only require argparse package for python versions < 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,17 @@
 #! /usr/bin/env python
 import sys
 
+extra = {}
 try:
 	from setuptools import setup
-	extra = {
-		'install_requires' : ['argparse']
-	}
+        if sys.version_info < (2,7):
+                extra['install_requires'] = ['argparse']
 	if sys.version_info >= (3,):
 		extra['use_2to3'] = True
 except ImportError:
 	from distutils.core import setup
-	extra = {
-		'dependencies' : ['argparse']
-	}
+        if sys.version_info < (2,7):
+                extra['dependencies'] = ['argparse']
 
 setup(name               = 'shovel',
 	version              = '0.1.10',


### PR DESCRIPTION
Python 2.7 has argparse built in, so having it as a dependency causes this error:

```
/usr/local/share/python/shovel:26: UserWarning: Module argparse was already imported from /usr/local/Cellar/python/2.7.4/Frameworks/Python.framework/Versions/2.7/lib/python2.7/argparse.pyc, but /usr/local/lib/python2.7/site-packages is being added to sys.path
```
