### PR TITLE
Fix for Python3 compatibility

### DIFF
--- a/shovel/__init__.py
+++ b/shovel/__init__.py
@@ -56,7 +56,7 @@ class Args(object):
         defaults.reverse()
         
         # Zip together the default arguments
-        self._args = zip(args, defaults)
+        self._args = list(zip(args, defaults))
         # And get the remaining args, and append them with
         # no default argument args
         self._args.extend((arg) for arg in args[len(self._args):])


### PR DESCRIPTION
## Issue

Under the latest Python3 I would get the following error when executing `shovel myfile.mytask` or `shovel help myfile.mytask`:

```
noah@ubuntu:~/git/tasks-proj$ shovel help deploy.server.create
Traceback (most recent call last):
  File "/usr/local/bin/shovel", line 83, in <module>
    shovel.help(*args, **kwargs)
  File "/usr/local/lib/python3.3/dist-packages/shovel/__init__.py", line 333, in help
    print(tasks[0].help())
  File "/usr/local/lib/python3.3/dist-packages/shovel/__init__.py", line 288, in help
    args = Args(self.spec)
  File "/usr/local/lib/python3.3/dist-packages/shovel/__init__.py", line 62, in __init__
    self._args.extend((arg) for arg in args[len(self._args):])
AttributeError: 'zip' object has no attribute 'extend'
```

I was able to resolve the issue with the included fix.  
## Testing the change

To see this breaking:

```
cd ~
git clone https://github.com/seomoz/shovel.git
cd shovel
sudo rm /usr/local/bin/shovel # Remove any existing shovel in your bin
sudo python3 setup.py install # Install current build
cd example
shovel help # See existing projects, this works
shovel help bar.args # Crashes
shovel bar.args 1 2 3 4 # Crashes
```

To see the fix in action:

```
cd ~
git clone https://github.com/nsantorello/shovel.git noah-shovel
cd noah-shovel
sudo rm /usr/local/bin/shovel # Remove any existing shovel in your bin
sudo python3 setup.py install # Install current build
cd example
shovel help # See existing projects, this still works
shovel help bar.args # This works now
shovel bar.args 1 2 3 4 # This works now
```
