### PR TITLE
add zsh autocomplete for shovel tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ shovel.egg-info/*
 *shovel.py
 shovel/*
 */shovel/*
-
+*/.shovel_tasks

--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ Command Line Utility
 --------------------
 
 Invoke shovel with the `shovel` command. If you would like to know more about
-what functions that shovel knows about:
-
-	shovel help
+what functions that shovel knows about, ask `shovel help` or `shovel tasks`.
 
 If you'd like more information on a specific task or module, you can ask for
 more information with shovel help. Shovel can figure out lots of things about
@@ -132,6 +130,17 @@ if we executed the following, then `a` and `b` would be passed as True:
 
 The reason for this is that flags are common for tasks, and it's a relatively
 unambiguous syntax. To a human, the meaning is clear, and now it is to shovel.
+
+### Command line auto-complete
+
+Available for zsh.
+
+1. Tell zsh where to find the script `_shovel`. For example, put it at
+   `~/.zsh/completion/_shovel` and somewhere in .zshrc before you call
+   `compinit` add the commond `fpath=(~/.zsh/completion/ $fpath)`.
+2. Navigate to a directory where you've tasks in `shovel.py` or under
+   `shovel/`, and hit `TAB` twice. Or, type the first couple letters of a
+   command and hit `TAB` once. Boom.
 
 Browser
 -------

--- a/_shovel
+++ b/_shovel
@@ -1,0 +1,8 @@
+#compdef shovel
+
+_shovel() {
+  if [[ -f shovel.py || -d shovel ]]; then
+    shovel tasks | cut -d " " -f 1 > .shovel_tasks
+    compadd `cat .shovel_tasks`
+  fi
+}

--- a/bin/shovel
+++ b/bin/shovel
@@ -43,6 +43,7 @@ import shovel
 import logging
 import os
 import sys
+
 if clargs.verbose:
     shovel.logger.setLevel(logging.DEBUG)
 
@@ -79,7 +80,26 @@ def parse(remaining):
 
 args, kwargs = parse(remaining)
 shovel.load()
-if clargs.method == 'help':
+
+if clargs.method == 'tasks':
+    tasks = [(tsk.fullname, tsk.doc.replace('\n', ' '))
+        for tsk in shovel.Task.find()]
+    if not tasks:
+      print('No tasks found!')
+    else:
+      width = 80
+      import shutil
+      try:
+          width, height = shutil.get_terminal_size(fallback=(0, width))
+      except AttributeError as e:
+        pass
+      max_name_len = max([len(e[0]) for e in tasks])
+      for tsk, doc in tasks:
+        pad = max_name_len + 2 - len(tsk)
+        doclen = width - max_name_len - 5
+        print('%s%s# %s' % (tsk, ' '*pad, doc[:doclen]))
+
+elif clargs.method == 'help':
     shovel.help(*args, **kwargs)
 elif clargs.method:
     # Try to get the first command provided


### PR DESCRIPTION
Because shovel is awesome, but typing isn't. Because `help` does some pretty printing, I created a new method for the command line tool `tasks` that dumps out an alphabetical list of task `.fullname`s and a documentation snippet with simple, flat formatting like rake's `--tasks`. Then added a little zsh script.

Now using autocomplete in my repos and projects, and loving it.

Thank you for shovel!
