### PR TITLE
Support path.py>=10.0 via s/path.path/path.Path/g

### DIFF
--- a/test/test_help.py
+++ b/test/test_help.py
@@ -5,9 +5,13 @@
 import unittest
 
 import os
-from path import path
 from shovel import help
 from shovel.tasks import Shovel
+try:
+    from path import Path
+except ImportError:  # pragma: no cover
+    # Pre-6.2 path.py support
+    from path import path as Path
 
 
 class TestHelp(unittest.TestCase):
@@ -61,7 +65,7 @@ class TestHelp(unittest.TestCase):
             help.shovel_help(self.shovel, 'two.widget').split('\n')]
         # We need to replace absolute paths in the test
         actual = [line.replace(os.getcwd(), '') for line in actual]
-        expected_path = path('/test/examples/help/two.py').normpath()
+        expected_path = Path('/test/examples/help/two.py').normpath()
         expected = [
             '==================================================',
             'widget',

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -7,7 +7,6 @@ import unittest
 from contextlib import contextmanager
 import logging
 import os
-from path import path
 import shovel
 import sys
 try:
@@ -15,6 +14,11 @@ try:
 except ImportError:  # pragma: no cover
     # Python 3 support
     from io import StringIO
+try:
+    from path import Path
+except ImportError:  # pragma: no cover
+    # Pre-6.2 path.py support
+    from path import path as Path
 
 
 @contextmanager
@@ -38,21 +42,21 @@ def logs():
 class TestRun(unittest.TestCase):
     '''Test our `run` method'''
     def stdout(self, pth, *args, **kwargs):
-        with path(pth):
+        with Path(pth):
             with capture() as out:
                 shovel.run(*args, **kwargs)
             return [line.strip() for line in
                 out.getvalue().strip().split('\n')]
 
     def stderr(self, pth, *args, **kwargs):
-        with path(pth):
+        with Path(pth):
             with capture('stderr') as out:
                 shovel.run(*args, **kwargs)
             return [line.strip() for line in
                 out.getvalue().strip().split('\n')]
 
     def logs(self, pth, *args, **kwargs):
-        with path(pth):
+        with Path(pth):
             with logs() as out:
                 shovel.run(*args, **kwargs)
             return [line.strip() for line in
@@ -77,7 +81,7 @@ class TestRun(unittest.TestCase):
         actual = self.logs('test/examples/run/basic', 'bar', '--verbose')
         # We have to replace absolue paths with relative ones
         actual = [line.replace(os.getcwd(), '') for line in actual]
-        expected_path = path('/test/examples/run/basic/shovel.py').normpath()
+        expected_path = Path('/test/examples/run/basic/shovel.py').normpath()
         expected = [
             'Loading ' + expected_path,
             'Found task bar in shovel']


### PR DESCRIPTION
I am working on an Arch Linux PKGBUILD for shovel and ran into an issue running the test suite: Arch Linux is on path.py 10.4, which [no longer provides the `path` class](https://github.com/jaraco/path.py/blob/a1633cfeb38003dd72306f78c4ad41de85f265e2/CHANGES.rst#100)., so tests bailed out with an `ImportError`.  This PR adds the usual `try`/`except ImportError` two-step for path.py so that the test suite is compatible with the most recent path.py releases as well as legacy releases.

Thanks in advance for your consideration!