### PR TITLE
Support SHOVEL_HOME

### DIFF
--- a/shovel/runner.py
+++ b/shovel/runner.py
@@ -69,6 +69,10 @@ def run(*args):
         if os.path.exists(path):  # pragma: no cover
             shovel.read(path, os.path.expanduser('~/'))
 
+    shovel_home = os.environ.get('SHOVEL_HOME', None)
+    if shovel_home and os.path.exists(shovel_home):
+        shovel.read(shovel_home)
+
     for path in ['shovel.py', 'shovel']:
         if os.path.exists(path):
             shovel.read(path)

--- a/shovel/runner.py
+++ b/shovel/runner.py
@@ -69,9 +69,9 @@ def run(*args):
         if os.path.exists(path):  # pragma: no cover
             shovel.read(path, os.path.expanduser('~/'))
 
-    shovel_home = os.environ.get('SHOVEL_HOME', None)
+    shovel_home = os.environ.get('SHOVEL_HOME')
     if shovel_home and os.path.exists(shovel_home):
-        shovel.read(shovel_home)
+        shovel.read(shovel_home, shovel_home)
 
     for path in ['shovel.py', 'shovel']:
         if os.path.exists(path):

--- a/test/examples/home/shovel/shovel.py
+++ b/test/examples/home/shovel/shovel.py
@@ -1,0 +1,5 @@
+from shovel import task
+
+@task
+def home():
+    print 'SHOVEL_HOME works'

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -116,3 +116,11 @@ class TestRun(unittest.TestCase):
         actual = self.stdout('test/examples/run/none', 'tasks')
         expected = ['No tasks found!']
         self.assertEqual(actual, expected)
+
+    def test_shovel_home(self):
+        '''Look for tasks in $SHOVEL_HOME'''
+        os.environ['SHOVEL_HOME'] = '%s/test/examples/home/shovel' % os.getcwd()
+        actual = self.stdout('test/examples/empty', 'home')
+        expected = ['SHOVEL_HOME works']
+        self.assertEqual(actual, expected)
+        del os.environ['SHOVEL_HOME']


### PR DESCRIPTION
This allows users to place a shovel task file at:

    /some/path/shovel/shovel.py

And then invoke tasks defined there via:

    SHOVEL_HOME=/some/path/shovel shovel mytask

@b4hand or @sistawendy Would you please take a look at this fairly simple change? This improvement would be really useful for our team.