### PR TITLE
Add bash completion to shovel

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -13,3 +13,22 @@ In the `completions/zsh` directory is a file to help with auto-completions in
 2. Navigate to a directory where you've tasks in `shovel.py` or under
     `shovel/`, and hit `TAB` twice. Or, type the first couple letters of a
     command and hit `TAB` once. Boom.
+
+Bash
+----
+In the `completions/bash` directory is a file to help with auto-completions in `bash`.  Installation:
+
+1.  Install [bash-completion](https://github.com/scop/bash-completion) if you haven't already.  
+  `brew install bash-completion@2`
+
+2.  Copy `completions/bash/shovel` to your local bash completions directory.
+
+```
+mkdir -p ~/.local/share/bash-completion/completions
+
+cp completions/bash/shovel ~/.local/share/bash-completion/completions/shovel
+```
+
+3.  Open a new terminal so the completions file will be sourced.
+
+4.  Navigate to a directory where tasks are in `shovel.py` or `shovel/` and hit `TAB` twice.  Or type the first couple letters of a command and hit `TAB` once.  Baam!

--- a/completions/bash/shovel
+++ b/completions/bash/shovel
@@ -1,0 +1,22 @@
+# shovel completion
+
+_shovel()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    case $prev in
+        --help|--version|-!(-*)[h])
+            return
+            ;;
+    esac
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $( compgen -W '$( _parse_help "$1" --help )' -- "$cur" ) )
+    elif [[ -f shovel.py || -d shovel ]]; then
+        COMPREPLY=( $( compgen -W '$(shovel tasks | cut -s -d"#" -f1) help tasks' -- "$cur") )
+    fi
+} &&
+complete -F _shovel shovel
+
+# ex: filetype=sh


### PR DESCRIPTION
FWIW, here are bash completions for shovel.

I tried to commit to bash-completions and they asked if you'd be interested in them.

https://github.com/scop/bash-completion/pull/279

I'm not really sure which side of the fence this belongs.

IMHO I don't think the shovel bash completions are in high demand, so probably adding them to the shovel repo is sufficient, but I'm open to other suggestions.
