### PR TITLE
Shovel version 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ venv
 *shovel.py
 */shovel/*
 */.shovel_tasks
-*.egg
+*.eggs

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ For pull requests, you'll need to add or change tests in support of your
 proposed change. To run the tests:
 
 ```python
-python setup.py nosetests
+nose2 -v
 ```
 
 This installs all the packages required to run tests, runs the tests and

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-coverage==4.5.1
-nose==1.3.0
-path.py==11.0
+coverage==6.3.2
+nose2==0.11.0
+path.py==12.5.0

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,11 @@
 
 import sys
 
-extra = {}
-
-try:
-    from setuptools import setup
-    if sys.version_info < (2, 7):
-        extra['install_requires'] = ['argparse']
-    if sys.version_info >= (3,):
-        extra['use_2to3'] = True
-except ImportError:
-    from distutils.core import setup
-    if sys.version_info < (2, 7):
-        extra['dependencies'] = ['argparse']
+from setuptools import setup
 
 setup(
     name='shovel',
-    version='0.4.0',
+    version='0.5.0',
     description='Not Rake, but Shovel',
     long_description='Execute python functions as tasks',
     url='http://github.com/seomoz/shovel',
@@ -32,7 +21,7 @@ setup(
     # scripts=['bin/shovel'],
     entry_points={'console_scripts': ['shovel = shovel:run']},
     setup_requires=['nose>=1.3'],
-    test_suite='nose.collector',
+    test_suite='nose2.collector.collector',
     tests_require=['nose>=1.3', 'path.py>=5.0', 'coverage>=3.7'],
     classifiers=[
         'License :: OSI Approved :: MIT License',
@@ -40,5 +29,4 @@ setup(
         'Intended Audience :: Developers',
         'Operating System :: OS Independent'
     ],
-    **extra
 )

--- a/test/examples/home/shovel/shovel.py
+++ b/test/examples/home/shovel/shovel.py
@@ -2,4 +2,4 @@ from shovel import task
 
 @task
 def home():
-    print 'SHOVEL_HOME works'
+    print('SHOVEL_HOME works')

--- a/test/test_run.py
+++ b/test/test_run.py
@@ -9,11 +9,9 @@ import logging
 import os
 import shovel
 import sys
-try:
-    from cStringIO import StringIO
-except ImportError:  # pragma: no cover
-    # Python 3 support
-    from io import StringIO
+
+from io import StringIO
+
 try:
     from path import Path
 except ImportError:  # pragma: no cover


### PR DESCRIPTION
Summary
======== 
Features included in this change:
* Shovel version 0.5.0
* Fixes #49 
* Fixes #50 
* Fixes `setup.py` to be compatible with setuptools 59.x and greater
* Covert testing to nose2
* `pur -r requiremenst.txt` to upgrade other requirements to recent versions
* Deprecate Python 2.x logic in `setup.py` and some test cases

Additional Info
===========
Many folks using shovel that have upgraded to setuptools 59.x are broken because of this error:
```
 pip install --user shovel
Collecting shovel
  Using cached shovel-0.4.0.tar.gz (15 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in shovel setup command: use_2to3 is invalid.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

This change resolves the setuptools compatibility issue in the `setup.py` and will fix many users of shovel whether they are installing via a CI/CD system or via pip using a requirements file. 

Test Plan
=======
* Run nose2 -v:
```
----------------------------------------------------------------------
Ran 39 tests in 0.066s

OK
```
* Build the setuptools package with:
```
python setup.py build
running build
running build_py
creating build
creating build/lib
creating build/lib/shovel
copying shovel/parser.py -> build/lib/shovel
copying shovel/runner.py -> build/lib/shovel
copying shovel/__init__.py -> build/lib/shovel
copying shovel/args.py -> build/lib/shovel
copying shovel/help.py -> build/lib/shovel
copying shovel/tasks.py -> build/lib/shovel
running egg_info
writing shovel.egg-info/PKG-INFO
writing dependency_links to shovel.egg-info/dependency_links.txt
writing entry points to shovel.egg-info/entry_points.txt
writing top-level names to shovel.egg-info/top_level.txt
reading manifest file 'shovel.egg-info/SOURCES.txt'
adding license file 'LICENSE'
writing manifest file 'shovel.egg-info/SOURCES.txt'
```
* Install shovel 0.5.0 locally to test install:
```
 pip3 install -e ./
Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/ss/repos/shovel
  Preparing metadata (setup.py) ... done
Installing collected packages: shovel
  Attempting uninstall: shovel
    Found existing installation: shovel 0.5.0
    Uninstalling shovel-0.5.0:
      Successfully uninstalled shovel-0.5.0
  Running setup.py develop for shovel
Successfully installed shovel-0.5.0
```
* Verify `shovel tasks` works with a local `shovel.py`